### PR TITLE
Implement keyword optimizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,12 @@ Run tests with:
 npm test
 ```
 
+## Search Index Optimization
+
+After each search, the app analyzes the returned documents and stores the top
+keywords in the browser's local storage. These keywords can be used as a basis
+for refining your Azure Search index or providing suggestions to the user.
+
 ## Available Scripts
 
 In the project directory, you can run:

--- a/src/optimizeIndex.ts
+++ b/src/optimizeIndex.ts
@@ -1,0 +1,26 @@
+export interface OptimizedKeywords {
+  keywords: string[];
+}
+
+export function optimizeIndexFromResults(results: { content?: string }[]): OptimizedKeywords {
+  const termFreq: Record<string, number> = {};
+
+  for (const r of results) {
+    const text = r.content || "";
+    const words = text.toLowerCase().match(/\b\w+\b/g) || [];
+    for (const w of words) {
+      termFreq[w] = (termFreq[w] || 0) + 1;
+    }
+  }
+
+  const keywords = Object.entries(termFreq)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 10)
+    .map(([word]) => word);
+
+  if (typeof localStorage !== "undefined") {
+    localStorage.setItem("optimizedKeywords", JSON.stringify(keywords));
+  }
+
+  return { keywords };
+}

--- a/src/searchAzure.ts
+++ b/src/searchAzure.ts
@@ -1,14 +1,16 @@
-interface SearchResult {
+export interface SearchResult {
   "@search.score": number;
   content?: string;
   [key: string]: any;
 }
 
-interface SearchResponse {
+export interface SearchResponse {
   "@odata.context": string;
   value: SearchResult[];
   [key: string]: any;
 }
+
+import { optimizeIndexFromResults } from "./optimizeIndex";
 
 export async function searchAzure(query: string): Promise<SearchResponse> {
   const apiKey = process.env.REACT_APP_AZURE_SEARCH_API_KEY;
@@ -37,5 +39,7 @@ export async function searchAzure(query: string): Promise<SearchResponse> {
     return { "@odata.context": "", value: [] };
   }
 
-  return await response.json();
+  const data = (await response.json()) as SearchResponse;
+  optimizeIndexFromResults(data.value);
+  return data;
 }


### PR DESCRIPTION
## Summary
- derive top keywords from search results
- store optimized keywords in local storage
- hook optimization into `searchAzure`
- document the optimization process

## Testing
- `npm test --silent --runTestsByPath src/App.test.tsx` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_688893ad21e88326829ffbe78a2599d8